### PR TITLE
Add predownload of GCA_* genomes instead of ENA api/fasta

### DIFF
--- a/bin/download_fasta_utils.py
+++ b/bin/download_fasta_utils.py
@@ -143,9 +143,13 @@ def load_genbank_locations(gca_accessions: set) -> dict[str, str | None]:
             accession = fields[0].split(".")[0]
             if accession in locations:
                 ftp_path = fields[19]
-                if ftp_path != "na":
-                    assembly = ftp_path.split("/")[-1]
-                    locations[accession] = f"{ftp_path}/{assembly}_genomic.fna.gz"
+                if ftp_path.startswith("https://ftp.ncbi.nlm.nih.gov/"):
+                    logging.warning(
+                        f"Unexpected ftp_path format for {accession}: {ftp_path}",
+                    )
+                    continue
+                assembly = ftp_path.split("/")[-1]
+                locations[accession] = f"{ftp_path}/{assembly}_genomic.fna.gz"
 
     return locations
 

--- a/bin/download_fasta_utils.py
+++ b/bin/download_fasta_utils.py
@@ -139,9 +139,8 @@ def load_genbank_locations(gca_accessions: set) -> dict[str, str | None]:
             if not line or line.startswith("#"):
                 continue
             fields = line.rstrip("\n").split("\t")
-            accession = fields[0].split(".")[
-                0
-            ]  # accession in the table always has version, remove it
+            # accession in the table always has version, remove it
+            accession = fields[0].split(".")[0]
             if accession in locations:
                 ftp_path = fields[19]
                 if ftp_path != "na":

--- a/bin/download_fasta_utils.py
+++ b/bin/download_fasta_utils.py
@@ -1,7 +1,12 @@
 import csv
 import gzip
+import http.client
 import logging
 import shutil
+import urllib.error as error
+
+# TODO replace urllib with requests in download_from_NCBI_FTP
+import urllib.request as request
 from ftplib import FTP, error_perm, error_proto, error_reply, error_temp
 from pathlib import Path
 
@@ -11,6 +16,10 @@ from botocore import UNSIGNED
 from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
 from retry import retry
+
+GENBANK_ASSEMBLY_SUMMARY = (
+    "https://ftp.ncbi.nlm.nih.gov/genomes/genbank/assembly_summary_genbank.txt"
+)
 
 
 def get_fasta_url(accession: str, analysis_ftp_field: str = "generated_ftp") -> str:
@@ -115,6 +124,52 @@ def download_from_ENA_FTP(accession: str, outpath: Path) -> Path:
         ftp.login()
         with open(outpath, "wb") as file:
             ftp.retrbinary(f"RETR {ftp_path}", file.write)
+    return check_if_empty_gz(outpath)
+
+
+def load_genbank_locations(gca_accessions: set) -> dict[str, str | None]:
+    """
+    Resolve GCA accessions to GenBank FTP URLs in a single pass.
+    :param gca_accessions: Set of GCA accessions
+    :return: Dictionary mapping GCA accessions to their GenBank FTP URLs
+    """
+    locations: dict[str, str | None] = {acc: None for acc in gca_accessions}
+
+    logging.info("Resolving GenBank FTP locations for GCA accessions")
+    with request.urlopen(GENBANK_ASSEMBLY_SUMMARY) as response:
+        for raw_line in response:
+            line = raw_line.decode("utf-8")
+            if line.startswith("#"):
+                continue
+
+            fields = line.rstrip("\n").split("\t")
+            accession = fields[0].split(".")[0]
+            if accession in locations:
+                ftp_path = fields[19]
+                if ftp_path != "na":
+                    assembly = ftp_path.split("/")[-1]
+                    locations[accession] = f"{ftp_path}/{assembly}_genomic.fna.gz"
+
+    return locations
+
+
+@retry(
+    (error.HTTPError, error.URLError, http.client.IncompleteRead), tries=5, delay=15, backoff=1.5
+)
+def download_from_NCBI_FTP(accession: str, fasta_url: str, outpath: Path) -> Path:
+    """
+    Download GCA fasta file using NCBI FTP link.
+    :param accession: NCBI genome accession (GCA_*)
+    :param fasta_url: FTP URL of the fasta file
+    :param outpath: Path to the folder where the fasta file will be saved
+    :return: Path to the downloaded fasta file
+    """
+    logging.debug(f"Downloading genome {accession} from NCBI FTP using URL {fasta_url}")
+    with request.urlopen(fasta_url) as response:
+        content = response.read()
+    with open(outpath, "wb") as out:
+        out.write(content)
+
     return check_if_empty_gz(outpath)
 
 

--- a/bin/download_fasta_utils.py
+++ b/bin/download_fasta_utils.py
@@ -1,12 +1,7 @@
 import csv
 import gzip
-import http.client
 import logging
 import shutil
-import urllib.error as error
-
-# TODO replace urllib with requests in download_from_NCBI_FTP
-import urllib.request as request
 from ftplib import FTP, error_perm, error_proto, error_reply, error_temp
 from pathlib import Path
 
@@ -15,7 +10,9 @@ import requests
 from botocore import UNSIGNED
 from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
+from requests.exceptions import RequestException
 from retry import retry
+from urllib3.exceptions import IncompleteRead
 
 GENBANK_ASSEMBLY_SUMMARY = (
     "https://ftp.ncbi.nlm.nih.gov/genomes/genbank/assembly_summary_genbank.txt"
@@ -136,14 +133,15 @@ def load_genbank_locations(gca_accessions: set) -> dict[str, str | None]:
     locations: dict[str, str | None] = {acc: None for acc in gca_accessions}
 
     logging.info("Resolving GenBank FTP locations for GCA accessions")
-    with request.urlopen(GENBANK_ASSEMBLY_SUMMARY) as response:
-        for raw_line in response:
-            line = raw_line.decode("utf-8")
-            if line.startswith("#"):
+    with requests.get(GENBANK_ASSEMBLY_SUMMARY, stream=True) as response:
+        response.raise_for_status()
+        for line in response.iter_lines(decode_unicode=True):
+            if not line or line.startswith("#"):
                 continue
-
             fields = line.rstrip("\n").split("\t")
-            accession = fields[0].split(".")[0]
+            accession = fields[0].split(".")[
+                0
+            ]  # accession in the table always has version, remove it
             if accession in locations:
                 ftp_path = fields[19]
                 if ftp_path != "na":
@@ -153,9 +151,7 @@ def load_genbank_locations(gca_accessions: set) -> dict[str, str | None]:
     return locations
 
 
-@retry(
-    (error.HTTPError, error.URLError, http.client.IncompleteRead), tries=5, delay=15, backoff=1.5
-)
+@retry((RequestException, IncompleteRead), tries=5, delay=15, backoff=1.5)
 def download_from_NCBI_FTP(accession: str, fasta_url: str, outpath: Path) -> Path:
     """
     Download GCA fasta file using NCBI FTP link.
@@ -165,10 +161,13 @@ def download_from_NCBI_FTP(accession: str, fasta_url: str, outpath: Path) -> Pat
     :return: Path to the downloaded fasta file
     """
     logging.debug(f"Downloading genome {accession} from NCBI FTP using URL {fasta_url}")
-    with request.urlopen(fasta_url) as response:
-        content = response.read()
-    with open(outpath, "wb") as out:
-        out.write(content)
+    with requests.get(fasta_url, stream=True) as response:
+        response.raise_for_status()
+
+        with open(outpath, "wb") as out:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if chunk:  # filters out keep-alive chunks
+                    out.write(chunk)
 
     return check_if_empty_gz(outpath)
 

--- a/bin/download_genome_accessions.py
+++ b/bin/download_genome_accessions.py
@@ -101,7 +101,7 @@ def main(skip_accessions_file, output_file, catalogues_metadata_file, gut_mappin
 
     logging.info("Step 5/5:")
     logging.info(
-        "Remove from the output all accessions that found in the input list of previously processed genomes..."
+        "Remove from the output all accessions that are found in the input list of previously processed genomes..."
     )
     if skip_accessions_file and skip_accessions_file.stat().st_size != 0:
         processed_df = pd.read_csv(
@@ -112,6 +112,13 @@ def main(skip_accessions_file, output_file, catalogues_metadata_file, gut_mappin
         ]
     else:
         logging.info("There is no list provided, skipping.")
+    # Put all GCA accessions first to make sure they are collected together in one batch.
+    # This makes predownloading of NCBI genomes downstream more efficient because
+    # fetching of the large TXT file with FTP links done for fewer number of batches.
+    gca_df = combined_df[combined_df["Genome_accession"].str.startswith("GCA")]
+    non_gca_df = combined_df[~combined_df["Genome_accession"].str.startswith("GCA")]
+
+    combined_df = pd.concat([gca_df, non_gca_df], ignore_index=True)
     combined_df.to_csv(output_file, sep="\t", header=False, index=False)
 
     logging.info(f"Finished successfully! List of genome accessions is saved to {output_file}")

--- a/bin/verify_contig_hashes_match.py
+++ b/bin/verify_contig_hashes_match.py
@@ -16,12 +16,51 @@ from download_fasta_utils import (
     download_from_ENA_API,
     download_from_ENA_FIRE,
     download_from_ENA_FTP,
+    download_from_NCBI_FTP,
+    load_genbank_locations,
 )
 
 
-def main(input_file, output_verified_file, output_invalid_file, download_folder, cleanup):
+def main(
+    input_file,
+    output_verified_file,
+    output_invalid_file,
+    download_folder,
+    cleanup,
+    predownload_ncbi_genomes=True,
+):
     validated_pairs = []
     invalid_pairs = []
+
+    if not download_folder.exists():
+        download_folder.mkdir(parents=True)
+        logging.debug(f"Directory {download_folder} is created")
+
+    # To address often ENA FASTA API failures for GCA accessions
+    # we first collect and download all GCA FASTA files to the download folder
+    # Later those files will be picked up during processing without additional downloads
+    if predownload_ncbi_genomes:
+        logging.debug("Predownload of NCBI genomes with GCA_* accessions is enabled")
+        logging.debug("Collecting GCA_* accessions for predownloading (if any)")
+        gca_accessions = set()
+        with open(input_file, "r") as handle:
+            reader = csv.reader(handle, delimiter="\t")
+            for row in reader:
+                genome = row[0]
+                if genome.startswith("GCA"):
+                    gca_accessions.add(genome)
+        if gca_accessions:
+            logging.debug(f"Predownloading {len(gca_accessions)} GCA_* fasta files from NCBI FTP")
+            gca_locations = load_genbank_locations(gca_accessions)
+            for gca_accession, url in gca_locations.items():
+                if not url:
+                    logging.debug(f"{gca_accession} No FTP location found. Skipping predownload")
+                    continue
+                outpath = download_folder / f"{gca_accession}.fa.gz"
+                try:
+                    download_from_NCBI_FTP(gca_accession, url, outpath)
+                except Exception as e:
+                    logging.debug(f"Predownload for {gca_accession} failed: {e}. Skipping")
 
     with open(input_file, "r") as input_handle:
         reader = csv.reader(input_handle, delimiter="\t")
@@ -115,10 +154,6 @@ def handle_fasta_processing(
     :param write_cache: If True, writes computed hashes to a cache file
     :return: set of md5 hashes of contigs
     """
-    if not download_folder.exists():
-        download_folder.mkdir(parents=True)
-        logging.debug(f"Directory {download_folder} is created")
-
     try:
         outpath = download_folder / f"{accession}.fa.gz"
         cache_path = download_folder / f"{accession}.hash"
@@ -243,6 +278,15 @@ def parse_args():
         action="store_true",
         help="Remove downloaded cache of checksums and download folder after execution",
     )
+    parser.add_argument(
+        "--no-predownload-ncbi-genomes",
+        dest="predownload_ncbi_genomes",
+        action="store_false",
+        help=(
+            "Disable predownload of NCBI genomes with GCA_* accessions. "
+            "Predownload helps to avoid ENA FASTA API failures, but slows execution on very small datasets"
+        ),
+    )
     parser.add_argument("--debug", action="store_true", help="Increase logging verbosity")
     return parser.parse_args()
 
@@ -275,4 +319,11 @@ def setup_logging(debug=False, error_logfile="ena_related_errors.log"):
 if __name__ == "__main__":
     args = parse_args()
     setup_logging(args.debug, args.errors)
-    main(args.input, args.output_verified, args.output_invalid, args.download_folder, args.cleanup)
+    main(
+        args.input,
+        args.output_verified,
+        args.output_invalid,
+        args.download_folder,
+        args.cleanup,
+        args.predownload_ncbi_genomes,
+    )

--- a/modules/local/verify_contig_hashes_match/main.nf
+++ b/modules/local/verify_contig_hashes_match/main.nf
@@ -13,12 +13,14 @@ process VERIFY_CONTIG_HASHES_MATCH {
     path("*.err")                          , emit: error_log, optional: true
 
     script:
+    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "$meta.id"
     def cleanup_flag = params.cleanup ? "--cleanup" : ""
     def debug_flag = params.debug ? "--debug" : ""
 
     """
     verify_contig_hashes_match.py \\
+        $args \\
         --input ${genome_to_assemblies_mapping} \\
         --output_verified ${prefix}.verified.tsv \\
         --output_invalid ${prefix}.invalid.tsv \\

--- a/modules/local/verify_contig_hashes_match/tests/main.nf.test
+++ b/modules/local/verify_contig_hashes_match/tests/main.nf.test
@@ -4,7 +4,34 @@ nextflow_process {
     script "../main.nf"
     process "VERIFY_CONTIG_HASHES_MATCH"
 
-    test("Find assemblies for the test list of accessions") {
+    test("Verify that MAG-assembly pairs are valid - no GCA predownload") {
+        config "./no_predownload.config"
+        when {
+            process {
+                """
+                input[0] = Channel.fromPath("${moduleDir}/tests/data/input_mapping.tsv", checkIfExists: true)
+                    .map { batch_file ->
+                        [[id:'test'], batch_file]
+                    }
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            with(process.out.verified_pairs) {
+                assert path(get(0)[1]).readLines().contains('ERZ1022847	ERZ807141')
+                assert path(get(0)[1]).readLines().contains('GCA_938030915	ERZ6864471')
+                assert path(get(0)[1]).readLines().contains('CAMPAA01	ERZ12302816')
+            }
+            with(process.out.invalid_pairs) {
+                assert path(get(0)).readLines().contains('ERZ1462793	the contigs of this genome are not identical to the contigs in the primary assemblies ERZ807141')
+            }
+        }
+
+    }
+
+        test("Verify that MAG-assembly pairs are valid - GCA predownload enabled") {
 
         when {
             process {
@@ -31,7 +58,7 @@ nextflow_process {
 
     }
 
-    test("Find assemblies for the test list of accessions - stub") {
+    test("Verify that MAG-assembly pairs are valid - stub") {
         options "-stub"
 
         when {

--- a/modules/local/verify_contig_hashes_match/tests/main.nf.test.snap
+++ b/modules/local/verify_contig_hashes_match/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "Find assemblies for the test list of accessions - stub": {
+    "Verify that MAG-assembly pairs are valid - stub": {
         "content": [
             {
                 "0": [
@@ -36,6 +36,6 @@
             "nf-test": "0.9.0",
             "nextflow": "25.04.1"
         },
-        "timestamp": "2026-01-06T15:39:10.691044"
+        "timestamp": "2026-01-08T12:00:54.057082"
     }
 }

--- a/modules/local/verify_contig_hashes_match/tests/no_predownload.config
+++ b/modules/local/verify_contig_hashes_match/tests/no_predownload.config
@@ -1,0 +1,5 @@
+process {
+    withName: VERIFY_CONTIG_HASHES_MATCH {
+        ext.args = '--no-predownload-ncbi-genomes'
+    }
+}


### PR DESCRIPTION
### Problem description
In the pipeline, processing of MAGs implemented sequentially: download one MAG - download its assembly - compute hash of the sequence - compare, than next one...
The problem is that for one-by-one download of accessions that start with `GCA_*` I could only use ENA API `https://www.ebi.ac.uk/ena/browser/api/fasta/`. It starts to go crazy if used frequently (responds with empty files). I initially solved this with `retry` but it makes the execution so much slower that it's unacceptable. 

### Solution
I've added a bit ugly, but efficient workaround. Now all GCA MAGs are downloaded together (not one by one) before the processing of genomes starts. This download approach based on a parsing of a huge TXT file containing links to all file locations in Genbank: `https://ftp.ncbi.nlm.nih.gov/genomes/genbank/assembly_summary_genbank.txt`. Because the parsing is slow it's done only once for all GCA MAGs in a batch. 

I also added sorting of the input file with accessions (that is split in batches for processing) to make sure that all GCAs are collected together and we only parse `assembly_summary_genbank.txt` as many times as necessary. 

### What as done

- `load_genbank_locations()` and `download_from_NCBI_FTP()` functions created to parse Genbank summary TXT file and download genomes from NCBI URL
- new argument `--no-predownload-ncbi-genomes` to enable this default behaviour
- added a test with `--no-predownload-ncbi-genomes`
- added sorting of the input file to the script that creates input files [download_genome_accessions.py‎](https://github.com/EBI-Metagenomics/MAG-to-assembly-pipeline/pull/6/changes#diff-4c21e42de6f509ff8f74c520647025ce0c379bdefb36ec523e0eaa33b1a0ce59)
